### PR TITLE
Fix haxelib package

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -3,11 +3,10 @@
   "license": "Apache",
   "tags": ["cross","haxe","random","game"],
   "description": "Pseudorandom number generator",
-  "contributors": ["flashultra"],
+  "contributors": ["flashultra", "NQNStudios"],
+  "classPath": "src/",
   "releasenote": "Initial version",
   "version": "0.0.1",
   "url": "https://github.com/flashultra/hxprng",
-  "dependencies": {
-
-  }
+  "main": "sample.Main"
 }

--- a/src/hxprng/PCG32.hx
+++ b/src/hxprng/PCG32.hx
@@ -21,6 +21,8 @@
  *       http://www.pcg-random.org
  */
 
+package hxprng;
+
 import haxe.Timer;
 import haxe.Int32;
 import haxe.Int64;

--- a/src/sample/Main.hx
+++ b/src/sample/Main.hx
@@ -1,3 +1,7 @@
+package sample;
+
+import hxprng.PCG32;
+
 class Main {
 
     static function main() {


### PR DESCRIPTION
Closed #1.

I reorganized the files and modified haxelib.json so haxelib for Haxe 4 can locate and import the library. To test it, with haxe 4 installed:

```
$ git clone https://github.com/NQNStudios/hxprng.git
$ haxelib dev hxprng hxprng
$ haxelib install ihx
$ haxelib run ihx
>> addlib hxprng
>> new hxprng.PCG32().random(6)
```